### PR TITLE
Added urlencoding for file paths.

### DIFF
--- a/src/Resource/File.php
+++ b/src/Resource/File.php
@@ -49,12 +49,17 @@ class File extends AbstractResource
             . $library->id
             . '/file/'
             . '?reuse=' . $reuse
-            . '&p=' . $dir . $item->name;
+            . '&p=' . $this->urlencodePath($dir . $item->name);
 
         $response = $this->client->request('GET', $url);
         $downloadUrl = (string)$response->getBody();
 
         return preg_replace("/\"/", '', $downloadUrl);
+    }
+
+    protected function urlencodePath($path)
+    {
+        return implode('/', array_map('rawurlencode', explode('/', (string) $path)));
     }
 
     /**
@@ -217,7 +222,7 @@ class File extends AbstractResource
             . '/repos/'
             . $library->id
             . '/file/detail/'
-            . '?p=' . $remoteFilePath;
+            . '?p=' . $this->urlencodePath($remoteFilePath);
 
         $response = $this->client->request('GET', $url);
 
@@ -244,7 +249,7 @@ class File extends AbstractResource
             '%s/repos/%s/file/?p=%s',
             $this->clipUri($this->client->getConfig('base_uri')),
             $library->id,
-            $filePath
+            $this->urlencodePath($filePath)
         );
 
         $response = $this->client->request(
@@ -277,7 +282,7 @@ class File extends AbstractResource
             '%s/repos/%s/file/?p=%s',
             $this->clipUri($this->client->getConfig('base_uri')),
             $library->id,
-            $filePath
+            $this->urlencodePath($filePath)
         );
 
         $response = $this->client->request(
@@ -335,7 +340,7 @@ class File extends AbstractResource
             '%s/repos/%s/file/?p=%s',
             $this->clipUri($this->client->getConfig('base_uri')),
             $srcLibrary->id,
-            $srcFilePath
+            $this->urlencodePath($srcFilePath)
         );
 
         $response = $this->client->request(
@@ -395,7 +400,7 @@ class File extends AbstractResource
             . '/repos/'
             . $library->id
             . '/file/revision/'
-            . '?p=' . $dirItem->path . $dirItem->name
+            . '?p=' . $this->urlencodePath($dirItem->path . $dirItem->name)
             . '&commit_id=' . $fileHistoryItem->id;
 
         $response = $this->client->request('GET', $url);
@@ -437,7 +442,7 @@ class File extends AbstractResource
             . '/repos/'
             . $library->id
             . '/file/history/'
-            . '?p=' . $item->path . $item->name;
+            . '?p=' . $this->urlencodePath($item->path . $item->name);
 
         $response = $this->client->request('GET', $url);
 
@@ -471,7 +476,7 @@ class File extends AbstractResource
             '%s/repos/%s/file/?p=%s',
             $this->clipUri($this->client->getConfig('base_uri')),
             $library->id,
-            $item->path . $item->name
+            $this->urlencodePath($item->path . $item->name)
         );
 
         $response = $this->client->request(

--- a/test/unit/Resource/FileTest.php
+++ b/test/unit/Resource/FileTest.php
@@ -40,6 +40,34 @@ class FileTest extends TestCase
     }
 
     /**
+     * Test urlencodePath()
+     *
+     * @return void
+     */
+    public function testUrlencodePath()
+    {
+        // Arrange
+        $fileResource = $this->getMockBuilder(File::class)
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $path1 = '/foo#bar baz.txt';
+        $expectedEncodedPath1 = '/foo%23bar%20baz.txt';
+
+        $path2 = '/foo bar baz/foo#bar&baz.txt';
+        $expectedEncodedPath2 = '/foo%20bar%20baz/foo%23bar%26baz.txt';
+
+        // Act
+        $actualEncodedPath1 = $this->invokeMethod($fileResource, 'urlencodePath', [$path1]);
+        $actualEncodedPath2 = $this->invokeMethod($fileResource, 'urlencodePath', [$path2]);
+
+        // Assert
+        $this->assertSame($expectedEncodedPath1, $actualEncodedPath1);
+        $this->assertSame($expectedEncodedPath2, $actualEncodedPath2);
+    }
+
+    /**
      * Test getUploadUrl()
      *
      * @return void


### PR DESCRIPTION
Thank you for the great package!

While working with it, I noticed that it was not able to download files that had special characters in the name (i.e. "&", "#"). I know that this is not really common to have them in the path, but as long as Seafile allows to use them, such paths can appear.

My guess, that such characters corrupt the request URI. And while when downloading files it is no real harm, it can be dangerous when removing files, as when there is "&" in the directory name the rest of the path will be left out. And if there is the file with resulted path it will be removed instead.

So I wrote the method that urlescapes the path and added it to all File methods that forms such URIs.

I'm not an expert in guzzle, so I'm not sure it won't double encode something, so take a look, please. As far as tested everything is OK.

And one more thing. While testing methods, I noticed that File::rename() method causes an error with files, that reside in folders. It renames file OK, but after it yells that it cannot find the file with the old filename. I didn't have time to investigate this today, so maybe you could take a look?

Thanks one more time for the package. It helped me a lot.